### PR TITLE
Revamp texture map GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Texture Map Generator
 
-This repository contains a Tkinter-based GUI application for generating common texture maps (AO, Roughness, Normal, etc.) from source images. The interface uses themed widgets for a more modern look.
+This repository contains a web-based application for generating common texture maps (AO, Roughness, Normal, etc.) from source images. The interface uses a dark theme and runs in your browser.
 
 ## Structure
 
 - `texture_map_generator/`
   - `processing.py` – image processing utilities.
-  - `app.py` – main GUI application.
-- `main.py` – entry point to run the application.
+  - `web_app.py` – Flask web interface.
+  - `templates/` – HTML templates for the web UI.
+- `main.py` – entry point to run the web application.
 - `import MaxPlus.py` – previous example script kept for reference.
 
 ## Usage
@@ -18,4 +19,4 @@ Run the application with:
 python main.py
 ```
 
-Drag-and-drop images onto the window or use the "Выбрать изображение(я)" button. `ttk` styling provides a polished experience. Adjust parameters and save the generated maps.
+Open `http://localhost:5000` in your browser, upload images and the generated maps will be displayed.

--- a/main.py
+++ b/main.py
@@ -1,11 +1,9 @@
-from texture_map_generator.app import TextureMapApp
-import tkinterdnd2 as tkdnd
+from texture_map_generator.web_app import create_app
 
 
 def main() -> None:
-    root = tkdnd.TkinterDnD.Tk()
-    app = TextureMapApp(root)
-    root.mainloop()
+    app = create_app()
+    app.run(debug=True)
 
 
 if __name__ == "__main__":

--- a/texture_map_generator/app.py
+++ b/texture_map_generator/app.py
@@ -47,8 +47,30 @@ class TextureMapApp:
             style.theme_use("clam")
         except tk.TclError:
             pass
-        style.configure("TButton", padding=(PAD_X, PAD_Y))
-        style.configure("TCheckbutton", padding=(PAD_X, PAD_Y))
+        self.root.configure(bg="#2d2d2d")
+        style.configure(
+            "TFrame",
+            background="#2d2d2d",
+        )
+        style.configure(
+            "TLabelFrame",
+            background="#2d2d2d",
+            foreground="#ffffff",
+        )
+        style.configure(
+            "TLabel",
+            background="#2d2d2d",
+            foreground="#ffffff",
+        )
+        style.configure(
+            "TButton",
+            padding=(PAD_X, PAD_Y),
+            background="#444444",
+            foreground="#ffffff",
+            relief="flat",
+        )
+        style.map("TButton", background=[("active", "#666666")])
+        style.configure("TCheckbutton", padding=(PAD_X, PAD_Y), background="#2d2d2d", foreground="#ffffff")
 
         btn_frame = ttk.Frame(self.root)
         btn_frame.grid(row=0, column=0, sticky="w", padx=PAD_X, pady=PAD_Y)
@@ -125,16 +147,31 @@ class TextureMapApp:
 
         for idx, img in enumerate(self.original_images):
             maps = {}
-            frame = ttk.LabelFrame(self.preview_frame, text=os.path.basename(self.image_paths[idx]), padding=10)
+            frame = ttk.LabelFrame(
+                self.preview_frame,
+                text=os.path.basename(self.image_paths[idx]),
+                padding=10,
+            )
             frame.pack(padx=10, pady=10, fill="x")
 
-            map_list = ["Diffuse", "AO", "Roughness", "Normal", "Displacement", "Metallic", "Emissive"]
+            notebook = ttk.Notebook(frame)
+            notebook.pack(fill="both", expand=True)
+
+            map_list = [
+                "Diffuse",
+                "AO",
+                "Roughness",
+                "Normal",
+                "Displacement",
+                "Metallic",
+                "Emissive",
+            ]
             if img.shape[2] == 4:
                 map_list.insert(1, "Opacity")
 
-            for i, map_type in enumerate(map_list):
-                sub = ttk.Frame(frame)
-                sub.grid(row=i // 3, column=i % 3, padx=10, pady=5)
+            for map_type in map_list:
+                sub = ttk.Frame(notebook)
+                notebook.add(sub, text=map_type)
 
                 map_img = generate_map(
                     map_type,

--- a/texture_map_generator/templates/index.html
+++ b/texture_map_generator/templates/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Texture Map Generator</title>
+    <style>
+      body { background: #2d2d2d; color: #fff; font-family: sans-serif; }
+      .container { width: 80%%; margin: auto; text-align: center; padding-top: 50px; }
+      input[type=file] { margin: 20px 0; }
+      button { padding: 10px 20px; background: #444; color: #fff; border: none; }
+      button:hover { background: #666; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Texture Map Generator</h1>
+      <form action="/" method="post" enctype="multipart/form-data">
+        <input type="file" name="images" multiple accept="image/*"><br>
+        <button type="submit">Generate Maps</button>
+      </form>
+    </div>
+  </body>
+</html>

--- a/texture_map_generator/templates/result.html
+++ b/texture_map_generator/templates/result.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Texture Map Generator - Results</title>
+    <style>
+      body { background: #2d2d2d; color: #fff; font-family: sans-serif; }
+      .container { width: 90%%; margin: auto; }
+      .image-block { margin-bottom: 40px; }
+      .map { display: inline-block; margin: 10px; text-align: center; }
+      img { width: 256px; height: 256px; display: block; border: 1px solid #555; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Generated Maps</h1>
+      {% for item in results %}
+      <div class="image-block">
+        <h2>{{ item.name }}</h2>
+        {% for m, data in item.maps.items() %}
+        <div class="map">
+          <p>{{ m }}</p>
+          <img src="data:image/png;base64,{{ data }}" alt="{{ m }}">
+        </div>
+        {% endfor %}
+      </div>
+      {% endfor %}
+      <p><a href="/">Back</a></p>
+    </div>
+  </body>
+</html>

--- a/texture_map_generator/web_app.py
+++ b/texture_map_generator/web_app.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import base64
+import io
+from typing import List, Dict
+
+import cv2
+import numpy as np
+from flask import Flask, render_template, request
+
+from .processing import generate_map
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route('/', methods=['GET', 'POST'])
+    def index():
+        if request.method == 'POST':
+            files = request.files.getlist('images')
+            results: List[Dict[str, Dict[str, str]]] = []
+            for f in files:
+                data = np.frombuffer(f.read(), np.uint8)
+                img = cv2.imdecode(data, cv2.IMREAD_UNCHANGED)
+                if img is None:
+                    continue
+                if img.shape[2] == 4:
+                    img = cv2.cvtColor(img, cv2.COLOR_BGRA2RGB)
+                else:
+                    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+
+                map_list = [
+                    "Diffuse",
+                    "AO",
+                    "Roughness",
+                    "Normal",
+                    "Displacement",
+                    "Metallic",
+                    "Emissive",
+                ]
+                if img.shape[2] == 4:
+                    map_list.insert(1, "Opacity")
+
+                maps: Dict[str, str] = {}
+                for map_type in map_list:
+                    m = generate_map(map_type, img, 0.5)
+                    _, buf = cv2.imencode('.png', cv2.cvtColor(m, cv2.COLOR_RGB2BGR))
+                    maps[map_type] = base64.b64encode(buf).decode('utf-8')
+                results.append({'name': f.filename, 'maps': maps})
+            return render_template('result.html', results=results)
+        return render_template('index.html')
+
+    return app


### PR DESCRIPTION
## Summary
- modernize look with a dark theme
- organize map previews with tabs for easier navigation
- switch to a Flask-based web interface

## Testing
- `python -m py_compile main.py texture_map_generator/*.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68419353640c8331b2ddf9f548438823